### PR TITLE
ConfiguredStream.PrimaryKey should be [][]string

### DIFF
--- a/airbyte/catalog.go
+++ b/airbyte/catalog.go
@@ -50,7 +50,7 @@ type ConfiguredStream struct {
 	SyncMode            SyncMode            `json:"sync_mode"`
 	DestinationSyncMode DestinationSyncMode `json:"destination_sync_mode"`
 	CursorField         []string            `json:"cursor_field,omitempty"`
-	PrimaryKey          []string            `json:"primary_key,omitempty"`
+	PrimaryKey          [][]string          `json:"primary_key,omitempty"`
 	Projections         map[string]string   `json:"estuary.dev/projections"`
 }
 
@@ -62,7 +62,7 @@ func (s *ConfiguredStream) UnmarshalJSON(b []byte) error {
 		SyncMode            SyncMode            `json:"sync_mode"`
 		DestinationSyncMode DestinationSyncMode `json:"destination_sync_mode"`
 		CursorField         []string            `json:"cursor_field,omitempty"`
-		PrimaryKey          []string            `json:"primary_key,omitempty"`
+		PrimaryKey          [][]string          `json:"primary_key,omitempty"`
 		NSProjections       map[string]string   `json:"estuary.dev/projections"`
 		Projections         map[string]string   `json:"projections"`
 	}{}

--- a/airbyte/json_test.go
+++ b/airbyte/json_test.go
@@ -13,7 +13,7 @@ func TestConfiguredCatalogMarshaling(t *testing.T) {
             "stream": {"name": "foo","json_schema":true},
             "sync_mode": "incremental",
             "destination_sync_mode": "append",
-            "primary_key": ["/yea", "/boiiii"],
+            "primary_key": [["/yea"], ["/boiiii"]],
             "projections": {
                 "space": "/balls",
                 "blazing": "/saddles"


### PR DESCRIPTION
The primary key of a stream should be an array of arrays of strings,
I'm pretty sure this is just a typo in transcribing the spec into Go
structs.