### PR TITLE
Remove pointer indirection in sql string mapper

### DIFF
--- a/materialize/sql/sqlgen.go
+++ b/materialize/sql/sqlgen.go
@@ -230,14 +230,14 @@ func (mapper NullableTypeMapping) GetColumnType(col *Column) (*ResolvedColumnTyp
 // and/or content type into account when deciding what sql column type to generate.
 type StringTypeMapping struct {
 	Default       TypeMapper
-	ByFormat      map[string]*TypeMapper
-	ByContentType map[string]*TypeMapper
+	ByFormat      map[string]TypeMapper
+	ByContentType map[string]TypeMapper
 }
 
 // GetColumnType implements the TypeMapper interface
 func (mapping StringTypeMapping) GetColumnType(col *Column) (*ResolvedColumnType, error) {
 	var stringType = col.StringType
-	var resolvedMapper *TypeMapper
+	var resolvedMapper TypeMapper
 
 	if stringType != nil {
 		if len(stringType.Format) > 0 {
@@ -250,9 +250,9 @@ func (mapping StringTypeMapping) GetColumnType(col *Column) (*ResolvedColumnType
 	}
 
 	if resolvedMapper == nil {
-		resolvedMapper = &mapping.Default
+		resolvedMapper = mapping.Default
 	}
-	return (*resolvedMapper).GetColumnType(col)
+	return resolvedMapper.GetColumnType(col)
 }
 
 // ColumnTypeMapper selects a specific TypeMapper based on the type of the data that will be passed


### PR DESCRIPTION
The `TypeMapper` for string columns uses internal maps of formats and
content-types to specialized `TypeMapper`s. This maps needlessly stored
`*TypeMapper` instead of just using the interface directly, which made
them difficult to construct. This removes the extra pointer indirection.