### PR TITLE
materialize: don't call Load when in delta updates mode

### DIFF
--- a/materialize/.snapshots/TestIntegratedTransactorAndClient
+++ b/materialize/.snapshots/TestIntegratedTransactorAndClient
@@ -11,7 +11,7 @@ COMBINER:
       00000000  22 32 6e 64 2d 72 6f 75  6e 64 22                 |"2nd-round"|
     }
   },
-  Combined: ([]json.RawMessage) (len=4) {
+  Combined: ([]json.RawMessage) (len=6) {
     (json.RawMessage) (len=5) {
       00000000  22 6f 6e 65 22                                    |"one"|
     },
@@ -23,6 +23,12 @@ COMBINER:
     },
     (json.RawMessage) (len=6) {
       00000000  22 66 6f 75 72 22                                 |"four"|
+    },
+    (json.RawMessage) (len=1) {
+      00000000  35                                                |5|
+    },
+    (json.RawMessage) (len=5) {
+      00000000  22 73 69 78 22                                    |"six"|
     }
   },
   Destroyed: (bool) true,
@@ -33,6 +39,7 @@ COMBINER:
 })
 TRANSACTOR:
 (*materialize.testTransactor)({
+  loadNotExpected: (bool) true,
   LoadBindings: ([]int) (len=4) {
     (int) 0,
     (int) 0,
@@ -46,28 +53,34 @@ TRANSACTOR:
     (tuple.Tuple) (len=1) (4)
   },
   Loaded: (map[int][]interface {}) <nil>,
-  PrepareRx: (materialize.TransactionRequest_Prepare) flow_checkpoint:"\n\027\n\0202nd-flow-fixture\022\003\010\322\t" ,
-  PreparedTx: (flow.DriverCheckpoint) driver_checkpoint_json:"\"2nd-checkpoint\"" ,
-  StoreBindings: ([]int) (len=4) {
+  PrepareRx: (materialize.TransactionRequest_Prepare) flow_checkpoint:"\n\027\n\0203rd-flow-fixture\022\003\010\256," ,
+  PreparedTx: (flow.DriverCheckpoint) driver_checkpoint_json:"\"3rd-checkpoint\"" ,
+  StoreBindings: ([]int) (len=6) {
+    (int) 0,
+    (int) 0,
     (int) 0,
     (int) 0,
     (int) 0,
     (int) 0
   },
   StoreExists: ([]bool) <nil>,
-  StoreKeys: ([]tuple.Tuple) (len=4) {
+  StoreKeys: ([]tuple.Tuple) (len=6) {
     (tuple.Tuple) (len=1) (1),
     (tuple.Tuple) (len=1) (2),
     (tuple.Tuple) (len=1) ("three"),
-    (tuple.Tuple) (len=1) (4)
+    (tuple.Tuple) (len=1) (4),
+    (tuple.Tuple) (len=1) ("five"),
+    (tuple.Tuple) (len=1) ("six")
   },
-  StoreValues: ([]tuple.Tuple) (len=4) {
+  StoreValues: ([]tuple.Tuple) (len=6) {
     (tuple.Tuple) (len=2) ("val", 1),
     (tuple.Tuple) (len=2) ("val", 2),
     (tuple.Tuple) (len=2) ("val", 3),
-    (tuple.Tuple) (len=2) ("val", 4)
+    (tuple.Tuple) (len=2) ("val", 4),
+    (tuple.Tuple) (len=2) ("val", 5),
+    (tuple.Tuple) (len=2) ("val", 6)
   },
-  StoreDocs: ([]json.RawMessage) (len=4) {
+  StoreDocs: ([]json.RawMessage) (len=6) {
     (json.RawMessage) (len=5) {
       00000000  22 6f 6e 65 22                                    |"one"|
     },
@@ -79,6 +92,12 @@ TRANSACTOR:
     },
     (json.RawMessage) (len=6) {
       00000000  22 66 6f 75 72 22                                 |"four"|
+    },
+    (json.RawMessage) (len=6) {
+      00000000  22 66 69 76 65 22                                 |"five"|
+    },
+    (json.RawMessage) (len=5) {
+      00000000  22 73 69 78 22                                    |"six"|
     }
   }
 })


### PR DESCRIPTION
This is a regression fix from the prior Transactor and client work.
When DeltaUpdates is true, the expectation is that Transactor.Load
is skipped, as it may not make sense / be a panic implementation for
drivers which are ONLY delta-updates.

Add new test coverage as well.

Issue estuary/flow#272