### PR TITLE
Combiners return stats when drained

### DIFF
--- a/flow/combiner.go
+++ b/flow/combiner.go
@@ -17,7 +17,7 @@ type Combiner interface {
 	// |full| is true if this document is a full reduction (ReduceLeft was called).
 	// |packedKey| is the FoundationDB tuple encoding of the document key.
 	// |packedValues| are materialized fields of the materialization.
-	Drain(func(full bool, doc json.RawMessage, packedKey, packedValues []byte) error) error
+	Drain(func(full bool, doc json.RawMessage, packedKey, packedValues []byte) error) (*CombineAPI_Stats, error)
 	// Destroy the Combiner.
 	Destroy()
 }
@@ -63,19 +63,35 @@ func (c *MockCombiner) AddDrainFixture(full bool, doc interface{}, key, values t
 }
 
 // Drain invokes the callback with pre-arranged fixtures.
-func (c *MockCombiner) Drain(fn func(full bool, doc json.RawMessage, packedKey, packedValues []byte) error) error {
+func (c *MockCombiner) Drain(fn func(full bool, doc json.RawMessage, packedKey, packedValues []byte) error) (*CombineAPI_Stats, error) {
 	for i := range c.drainFull {
 		if err := fn(c.drainFull[i], c.drainDocs[i], c.drainKeys[i], c.drainValues[i]); err != nil {
-			return err
+			return nil, err
 		}
 	}
+
+	var dAndB = func(docs []json.RawMessage) *DocsAndBytes {
+		var bytes uint64 = 0
+		for _, d := range docs {
+			bytes = bytes + uint64(len(d))
+		}
+		return &DocsAndBytes{
+			Docs:  uint64(len(docs)),
+			Bytes: bytes,
+		}
+	}
+
+	var stats = new(CombineAPI_Stats)
+	stats.Left = dAndB(c.Reduced)
+	stats.Right = dAndB(c.Combined)
+	stats.Out = dAndB(c.drainDocs)
 
 	c.drainFull = nil
 	c.drainKeys = nil
 	c.drainValues = nil
 	c.drainDocs = nil
 
-	return nil
+	return stats, nil
 }
 
 // Destroy sets Destroyed to true.

--- a/materialize/client_transactor_test.go
+++ b/materialize/client_transactor_test.go
@@ -70,7 +70,9 @@ func TestIntegratedTransactorAndClient(t *testing.T) {
 		LogCommitted:    logCommittedOp,
 		Acknowledged:    client.NewAsyncOperation(),
 	}
-	require.NoError(t, rpc.StartCommit(ops))
+	stats, err := rpc.StartCommit(ops)
+	require.NoError(t, err)
+	require.NotNil(t, stats[0])
 
 	// Pipeline the next transaction.
 	// Reset Loaded fixture, and load some documents.
@@ -104,7 +106,9 @@ func TestIntegratedTransactorAndClient(t *testing.T) {
 		LogCommitted:    logCommittedOp,
 		Acknowledged:    client.NewAsyncOperation(),
 	}
-	require.NoError(t, rpc.StartCommit(ops))
+	stats, err = rpc.StartCommit(ops)
+	require.NoError(t, err)
+	require.NotNil(t, stats[0])
 
 	// Clear the key cache, and switch to delta-updates mode.
 	// Then pipeline the next delta-updates transaction.
@@ -136,7 +140,9 @@ func TestIntegratedTransactorAndClient(t *testing.T) {
 		LogCommitted:    logCommittedOp,
 		Acknowledged:    client.NewAsyncOperation(),
 	}
-	require.NoError(t, rpc.StartCommit(ops))
+	stats, err = rpc.StartCommit(ops)
+	require.NoError(t, err)
+	require.NotNil(t, stats[0])
 
 	require.NoError(t, ops.DriverCommitted.Err())
 	logCommittedOp.Resolve(nil)


### PR DESCRIPTION
Updates the combiner and client types to return statistics. These
changes setup flow to be able to publish the stats that are returned
from the Rust bindings.