### PR TITLE
materialize/sql: Relax root document requirement in delta update mode

### DIFF
--- a/materialize/sql/driver.go
+++ b/materialize/sql/driver.go
@@ -103,6 +103,7 @@ func (d *Driver) Validate(ctx context.Context, req *pm.ValidateRequest) (*pm.Val
 		var target = resource.Path().Join()
 		current, constraints, err := loadConstraints(
 			target,
+			resource.DeltaUpdates(),
 			&spec.Collection,
 			existing,
 		)
@@ -341,6 +342,7 @@ func (d *Driver) Transactions(stream pm.Driver_TransactionsServer) error {
 // collection given the (possible) existing binding.
 func loadConstraints(
 	target string,
+	deltaUpdates bool,
 	collection *pf.CollectionSpec,
 	existing map[string]*pf.MaterializationSpec_Binding,
 ) (
@@ -356,7 +358,7 @@ func loadConstraints(
 
 	var constraints map[string]*pm.Constraint
 	if current == nil {
-		constraints = ValidateNewSQLProjections(collection)
+		constraints = ValidateNewSQLProjections(collection, deltaUpdates)
 	} else {
 		constraints = ValidateMatchesExisting(current, collection)
 	}

--- a/materialize/sql/spec_mapping.go
+++ b/materialize/sql/spec_mapping.go
@@ -89,7 +89,7 @@ func generateApplyStatements(
 ) ([]string, error) {
 	var target = ResourcePath(spec.ResourcePath).Join()
 
-	current, constraints, err := loadConstraints(target, &spec.Collection, existing)
+	current, constraints, err := loadConstraints(target, spec.DeltaUpdates, &spec.Collection, existing)
 	if err != nil {
 		return nil, err
 	}

--- a/materialize/sql/validate.go
+++ b/materialize/sql/validate.go
@@ -50,7 +50,7 @@ func ValidateSelectedFields(constraints map[string]*pm.Constraint, proposed *pf.
 // **new** materialization (one that is not running and has never been Applied). Note that this will
 // "recommend" all projections of single scalar types, which is what drives the default field
 // selection in flowctl.
-func ValidateNewSQLProjections(proposed *pf.CollectionSpec) map[string]*pm.Constraint {
+func ValidateNewSQLProjections(proposed *pf.CollectionSpec, deltaUpdates bool) map[string]*pm.Constraint {
 	var constraints = make(map[string]*pm.Constraint)
 	for _, projection := range proposed.Projections {
 		var constraint = new(pm.Constraint)
@@ -58,6 +58,9 @@ func ValidateNewSQLProjections(proposed *pf.CollectionSpec) map[string]*pm.Const
 		case projection.IsPrimaryKey:
 			constraint.Type = pm.Constraint_LOCATION_REQUIRED
 			constraint.Reason = "All Locations that are part of the collections key are required"
+		case projection.IsRootDocumentProjection() && deltaUpdates:
+			constraint.Type = pm.Constraint_LOCATION_RECOMMENDED
+			constraint.Reason = "The root document should usually be materialized"
 		case projection.IsRootDocumentProjection():
 			constraint.Type = pm.Constraint_LOCATION_REQUIRED
 			constraint.Reason = "The root document must be materialized"


### PR DESCRIPTION
The goal here is to be able to say `exclude: ["flow_document"]` in a materialization binding, so that we don't get a big blob-o-JSON in the output dataset when it's not actually necessary or desired. This change relaxes things so that when delta updates are used the root document is only `RECOMMENDED`.

However, individual connectors may need to be modified to actually make use of this. For instance `materialize-bigquery`, where I want to use this capability at the moment, has baked-in assumptions about the existence of a binding for the root document which need to be untangled before things actually work as intended.